### PR TITLE
docs: prompt replacement for PayPal client ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Static site for Wild West Wall Art showcasing metal, acrylic, and canvas prints 
 Open `index.html` in a browser to view the site locally.
 
 
-Replace `YOUR_PAYPAL_CLIENT_ID` in `index.html` with a live client ID from your PayPal Business account.
+Replace `REPLACE_WITH_LIVE_PAYPAL_CLIENT_ID` in `index.html` with a live client ID from your PayPal Business account.
 
 ## Deployment
 

--- a/index.html
+++ b/index.html
@@ -99,7 +99,7 @@
     <p>&copy; 2024 Wild West Wall Art</p>
   </footer>
   
-  <script src="https://www.paypal.com/sdk/js?client-id=AQzQReGx2gCRwD7kWOFi5ntaDSGbIHcheIeW9fJ0gJHV9onPhjDuD6EjgVXASJIJVe6L3LC84kOboE28&currency=USD&buyer-country=US"></script>
+  <script src="https://www.paypal.com/sdk/js?client-id=REPLACE_WITH_LIVE_PAYPAL_CLIENT_ID&currency=USD&buyer-country=US"></script>
   <script>
   const prices = {
     Metallic: { "20x40": 220, "24x36": 150, "20x30": 120, "16x24": 70 },


### PR DESCRIPTION
## Summary
- replace hardcoded PayPal client ID with placeholder to encourage using a live Business client ID
- clarify README instructions for setting PayPal client ID

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a1c4e7ceac832d9f9cf29bd0ffc551

## Summary by Sourcery

Documentation:
- Use REPLACE_WITH_LIVE_PAYPAL_CLIENT_ID as the PayPal client ID placeholder in index.html and update README instructions accordingly