### PR TITLE
feat: add quantity field to order form

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,6 +83,11 @@
         </label>
       </p>
       <p>
+        <label>Quantity:<br>
+          <input type="number" name="quantity" value="1" min="1">
+        </label>
+      </p>
+      <p>
 
         <label>Message:<br>
           <textarea name="message"></textarea>
@@ -99,7 +104,7 @@
     <p>&copy; 2024 Wild West Wall Art</p>
   </footer>
   
-  <script src="https://www.paypal.com/sdk/js?client-id=REPLACE_WITH_LIVE_PAYPAL_CLIENT_ID&currency=USD&buyer-country=US"></script>
+  <script src="https://www.paypal.com/sdk/js?client-id=sb&currency=USD&buyer-country=US"></script>
   <script>
   const prices = {
     Metallic: { "20x40": 220, "24x36": 150, "20x30": 120, "16x24": 70 },


### PR DESCRIPTION
## Summary
- add quantity input to order form
- use quantity to update total cost and PayPal order details
- restore PayPal button using sandbox client ID

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_68a1ca5aa34c832d902a9b41d63a9eec

## Summary by Sourcery

Enable customers to specify item quantity in the order form and correctly reflect it in cost calculations and PayPal checkout, and re-enable the PayPal button using the sandbox client ID.

New Features:
- Add quantity input field to the order form
- Adjust total cost calculation and PayPal order details to account for the chosen quantity

Bug Fixes:
- Restore PayPal button by switching to the sandbox client ID