### PR TITLE
feat: add quantity field to order form

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,6 +83,11 @@
         </label>
       </p>
       <p>
+        <label>Quantity:<br>
+          <input type="number" name="quantity" value="1" min="1" step="1">
+        </label>
+      </p>
+      <p>
 
         <label>Message:<br>
           <textarea name="message"></textarea>
@@ -99,7 +104,7 @@
     <p>&copy; 2024 Wild West Wall Art</p>
   </footer>
   
-  <script src="https://www.paypal.com/sdk/js?client-id=REPLACE_WITH_LIVE_PAYPAL_CLIENT_ID&currency=USD&buyer-country=US"></script>
+  <script src="https://www.paypal.com/sdk/js?client-id=sb&currency=USD&buyer-country=US"></script>
   <script>
   const prices = {
     Metallic: { "20x40": 220, "24x36": 150, "20x30": 120, "16x24": 70 },
@@ -116,7 +121,7 @@
   function updateTotal() {
     const finish = finishSelect.value;
     const size = sizeSelect.value;
-    const quantity = parseInt(quantityInput.value, 10) || 1;
+    const quantity = Math.max(parseInt(quantityInput.value, 10) || 1, 1);
     const itemPrice = prices[finish][size];
     const total = itemPrice * quantity + shippingCost;
     totalDisplay.textContent = `Total: $${total.toFixed(2)} (including $${shippingCost} shipping)`;


### PR DESCRIPTION
## Summary
- add quantity input to order form
- use quantity to update total cost and PayPal order details
- restore PayPal button using sandbox client ID
- validate quantity as whole numbers no less than one

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_68a1ca5aa34c832d902a9b41d63a9eec

## Summary by Sourcery

Add and validate a quantity field in the order form, update the total cost and PayPal integration to account for quantity, and restore the PayPal button using the sandbox client ID.

New Features:
- Add quantity input field to order form with a minimum value of one
- Include quantity in total cost calculation and PayPal order details

Enhancements:
- Switch PayPal SDK to use sandbox client ID for testing